### PR TITLE
Fix type errors and add missing UI primitives

### DIFF
--- a/convex/analytics.ts
+++ b/convex/analytics.ts
@@ -15,7 +15,7 @@ export const getHiringMetrics = query({
     const totalInterviews = interviews.length
 
     // Active jobs (open status)
-    const activeJobs = jobs.filter(job => job.status === 'open').length
+    const activeJobs = jobs.filter(job => job.status === 'active').length
 
     // Candidates by status
     const candidatesByStatus = candidates.reduce((acc, candidate) => {
@@ -58,17 +58,17 @@ export const getFunnelAnalysis = query({
       { stage: 'Applied', count: candidates.length, color: '#3b82f6' },
       {
         stage: 'Screening',
-        count: candidates.filter(c => ['screening', 'interviewed', 'offered', 'hired'].includes(c.status)).length,
+        count: candidates.filter(c => ['screening', 'interview', 'offer', 'hired'].includes(c.status)).length,
         color: '#8b5cf6'
       },
       {
         stage: 'Interview',
-        count: candidates.filter(c => ['interviewed', 'offered', 'hired'].includes(c.status)).length,
+        count: candidates.filter(c => ['interview', 'offer', 'hired'].includes(c.status)).length,
         color: '#06b6d4'
       },
       {
         stage: 'Offer',
-        count: candidates.filter(c => ['offered', 'hired'].includes(c.status)).length,
+        count: candidates.filter(c => ['offer', 'hired'].includes(c.status)).length,
         color: '#10b981'
       },
       {
@@ -100,7 +100,7 @@ export const getTimeToHire = query({
 
     const timeToHireData = candidates.map(candidate => {
       const applicationDate = candidate._creationTime
-      const hireDate = candidate.updatedAt || Date.now()
+      const hireDate = candidate.hiredAt || candidate.updatedAt || Date.now()
       const daysToHire = Math.ceil((hireDate - applicationDate) / (1000 * 60 * 60 * 24))
 
       return {
@@ -141,7 +141,7 @@ export const getSourceEffectiveness = query({
 
       acc[source].totalApplications++
       if (candidate.status === 'hired') acc[source].hired++
-      if (['interviewed', 'offered', 'hired'].includes(candidate.status)) {
+      if (['interview', 'offer', 'hired'].includes(candidate.status)) {
         acc[source].interviewed++
       }
 

--- a/convex/candidates.ts
+++ b/convex/candidates.ts
@@ -72,10 +72,12 @@ export const create = mutation({
     skills: v.array(v.string()),
   },
   handler: async (ctx, args) => {
+    const now = Date.now()
     const candidateId = await ctx.db.insert("candidates", {
       ...args,
       appliedDate: new Date().toISOString().split('T')[0],
       status: "applied",
+      updatedAt: now,
       evaluation: {
         overall: 0,
         technical: 0,
@@ -107,12 +109,23 @@ export const updateStatus = mutation({
       v.literal("screening"),
       v.literal("interview"),
       v.literal("offer"),
+      v.literal("hired"),
       v.literal("rejected"),
       v.literal("withdrawn")
     ),
   },
   handler: async (ctx, args) => {
-    await ctx.db.patch(args.id, { status: args.status });
+    const now = Date.now()
+    const updates: Record<string, any> = {
+      status: args.status,
+      updatedAt: now,
+    }
+
+    if (args.status === "hired") {
+      updates.hiredAt = now
+    }
+
+    await ctx.db.patch(args.id, updates);
 
     // Add to timeline
     await ctx.db.insert("timeline", {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -11,12 +11,14 @@ export default defineSchema({
     github: v.optional(v.string()),
     portfolio: v.optional(v.string()),
     position: v.string(),
+    source: v.optional(v.string()),
     appliedDate: v.string(),
     status: v.union(
       v.literal("applied"),
       v.literal("screening"),
       v.literal("interview"),
       v.literal("offer"),
+      v.literal("hired"),
       v.literal("rejected"),
       v.literal("withdrawn")
     ),
@@ -28,6 +30,8 @@ export default defineSchema({
     resumeFilename: v.optional(v.string()),
     coverLetter: v.optional(v.id("_storage")),
     coverLetterFilename: v.optional(v.string()),
+    updatedAt: v.optional(v.number()),
+    hiredAt: v.optional(v.number()),
     evaluation: v.object({
       overall: v.number(),
       technical: v.number(),
@@ -101,6 +105,7 @@ export default defineSchema({
       v.literal("interview"),
       v.literal("assessment"),
       v.literal("offer"),
+      v.literal("hired"),
       v.literal("rejected"),
       v.literal("withdrawn")
     ),

--- a/src/app/careers/[id]/page.tsx
+++ b/src/app/careers/[id]/page.tsx
@@ -7,7 +7,7 @@ import {
   ArrowLeft, MapPin, Clock, Briefcase, DollarSign, Users, Calendar,
   FileText, Upload, Github, Linkedin, Globe, CheckCircle, AlertCircle
 } from 'lucide-react'
-import { toast } from 'sonner'
+import { useToast } from '@/hooks/use-toast'
 
 // This would come from Convex
 const job = {
@@ -55,6 +55,7 @@ const job = {
 
 export default function JobDetailsPage() {
   const params = useParams()
+  const { toast } = useToast()
   const [isApplying, setIsApplying] = useState(false)
   const [submitted, setSubmitted] = useState(false)
   const [formData, setFormData] = useState({
@@ -81,12 +82,19 @@ export default function JobDetailsPage() {
 
     // Validation
     if (!formData.firstName || !formData.lastName || !formData.email || !formData.resumeFile) {
-      toast.error('Please fill in all required fields')
+      toast({
+        title: 'Missing information',
+        description: 'Please fill in all required fields before submitting your application.',
+        variant: 'destructive',
+      })
       return
     }
 
     // In a real app, this would submit to Convex
-    toast.success('Application submitted successfully!')
+    toast({
+      title: 'Application submitted',
+      description: `Thanks for applying to the ${job.title} role. We'll review your details shortly.`,
+    })
     setSubmitted(true)
     setIsApplying(false)
   }
@@ -95,7 +103,11 @@ export default function JobDetailsPage() {
     const file = e.target.files?.[0]
     if (file) {
       if (file.size > 5 * 1024 * 1024) {
-        toast.error('File size must be less than 5MB')
+        toast({
+          title: 'File too large',
+          description: 'Please upload a resume that is smaller than 5MB.',
+          variant: 'destructive',
+        })
         return
       }
       setFormData({ ...formData, resumeFile: file })

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -17,6 +17,7 @@ const statusColors = {
   screening: 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400',
   interview: 'bg-purple-100 text-purple-800 dark:bg-purple-900/20 dark:text-purple-400',
   offer: 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400',
+  hired: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-400',
   rejected: 'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400',
   applied: 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400',
   withdrawn: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400',
@@ -204,6 +205,7 @@ export default function JobDetailPage() {
                 <option value="offer">Offer</option>
                 <option value="rejected">Rejected</option>
                 <option value="withdrawn">Withdrawn</option>
+                <option value="hired">Hired</option>
               </select>
             </div>
           </div>

--- a/src/components/modals/job-creation-modal.tsx
+++ b/src/components/modals/job-creation-modal.tsx
@@ -16,8 +16,7 @@ const jobTypes = [
   { value: 'full-time', label: 'Full-time' },
   { value: 'part-time', label: 'Part-time' },
   { value: 'contract', label: 'Contract' },
-  { value: 'internship', label: 'Internship' },
-]
+] as const
 
 const departments = [
   'Engineering',
@@ -38,17 +37,18 @@ const urgencyLevels = [
   { value: 'high', label: 'High Priority', color: 'text-red-600' },
 ]
 
+type JobType = (typeof jobTypes)[number]['value']
+
 interface JobFormData {
   title: string
   department: string
   location: string
-  type: string
+  type: JobType
   urgency: 'low' | 'medium' | 'high'
   salaryMin: string
   salaryMax: string
   description: string
   requirements: string[]
-  status: 'active' | 'paused' | 'closed'
 }
 
 export function JobCreationModal({ isOpen, onClose }: JobCreationModalProps) {
@@ -66,7 +66,6 @@ export function JobCreationModal({ isOpen, onClose }: JobCreationModalProps) {
     salaryMax: '',
     description: '',
     requirements: [''],
-    status: 'active',
   })
 
   const [errors, setErrors] = useState<Partial<Record<keyof JobFormData, string>>>({})
@@ -125,8 +124,6 @@ export function JobCreationModal({ isOpen, onClose }: JobCreationModalProps) {
         salaryMax,
         description: formData.description.trim(),
         requirements,
-        status: formData.status,
-        postedDate: new Date().toISOString().split('T')[0], // Today's date
       })
 
       toast({
@@ -145,7 +142,6 @@ export function JobCreationModal({ isOpen, onClose }: JobCreationModalProps) {
         salaryMax: '',
         description: '',
         requirements: [''],
-        status: 'active',
       })
 
       onClose()
@@ -260,7 +256,9 @@ export function JobCreationModal({ isOpen, onClose }: JobCreationModalProps) {
               </label>
               <select
                 value={formData.type}
-                onChange={(e) => setFormData({ ...formData, type: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, type: e.target.value as JobType })
+                }
                 className="input-clean"
               >
                 {jobTypes.map((type) => (
@@ -275,7 +273,9 @@ export function JobCreationModal({ isOpen, onClose }: JobCreationModalProps) {
               </label>
               <select
                 value={formData.urgency}
-                onChange={(e) => setFormData({ ...formData, urgency: e.target.value as any })}
+                onChange={(e) =>
+                  setFormData({ ...formData, urgency: e.target.value as JobFormData['urgency'] })
+                }
                 className="input-clean"
               >
                 {urgencyLevels.map((level) => (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = ({ children, ...props }: DialogPrimitive.DialogPortalProps) => (
+  <DialogPrimitive.Portal {...props}>
+    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
+      {children}
+    </div>
+  </DialogPrimitive.Portal>
+)
+
+DialogPortal.displayName = DialogPrimitive.Portal.displayName
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/80 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:animate-in data-[state=open]:fade-in', className)}
+    {...props}
+  />
+))
+
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed z-50 grid w-full gap-4 rounded-t-lg border bg-background p-6 shadow-lg sm:max-w-lg sm:rounded-lg',
+        'data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=closed]:slide-out-to-bottom-1/2',
+        'data-[state=open]:animate-in data-[state=open]:fade-in data-[state=open]:slide-in-from-bottom-1/2 sm:data-[state=open]:slide-in-from-bottom-0',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+)
+
+DialogHeader.displayName = 'DialogHeader'
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+)
+
+DialogFooter.displayName = 'DialogFooter'
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+))
+
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+const DialogClose = DialogPrimitive.Close
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react'
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+
+import { cn } from '@/lib/utils'
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
+      'data-[side=bottom]:animate-in data-[side=bottom]:slide-in-from-top-2',
+      'data-[side=top]:animate-in data-[side=top]:slide-in-from-bottom-2',
+      'data-[side=right]:animate-in data-[side=right]:slide-in-from-left-2',
+      'data-[side=left]:animate-in data-[side=left]:slide-in-from-right-2',
+      className
+    )}
+    {...props}
+  />
+))
+
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors',
+      'focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  />
+))
+
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn('mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+))
+
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
+    {...props}
+  />
+))
+
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuRadioGroup,
+}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const Label = React.forwardRef<
+  HTMLLabelElement,
+  React.ComponentPropsWithoutRef<'label'>
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+      className
+    )}
+    {...props}
+  />
+))
+
+Label.displayName = 'Label'
+
+export { Label }

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+type ProgressProps = React.ComponentPropsWithoutRef<'div'> & {
+  value?: number
+  indicatorClassName?: string
+  style?: (React.CSSProperties & { '--progress-background'?: string }) | undefined
+}
+
+const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ className, value = 0, indicatorClassName, style, ...props }, ref) => {
+    const clamped = Math.min(100, Math.max(0, value))
+
+    return (
+      <div
+        ref={ref}
+        className={cn('relative h-2 w-full overflow-hidden rounded-full bg-muted', className)}
+        style={style}
+        {...props}
+      >
+        <div
+          className={cn('h-full bg-primary transition-all', indicatorClassName)}
+          style={{
+            width: `${clamped}%`,
+            backgroundColor: 'var(--progress-background, hsl(var(--primary)))',
+          }}
+        />
+      </div>
+    )
+  }
+)
+
+Progress.displayName = 'Progress'
+
+export { Progress }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react'
+import * as SelectPrimitive from '@radix-ui/react-select'
+import { Check, ChevronDown, ChevronUp } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = 'popper', ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        'relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md',
+        'data-[side=bottom]:animate-in data-[side=bottom]:slide-in-from-top-1',
+        'data-[side=top]:animate-in data-[side=top]:slide-in-from-bottom-1',
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectPrimitive.ScrollUpButton className="flex items-center justify-center py-1">
+        <ChevronUp className="h-4 w-4" />
+      </SelectPrimitive.ScrollUpButton>
+      <SelectPrimitive.Viewport
+        className={cn('p-1', position === 'popper' && 'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]')}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectPrimitive.ScrollDownButton className="flex items-center justify-center py-1">
+        <ChevronDown className="h-4 w-4" />
+      </SelectPrimitive.ScrollDownButton>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn('px-2 py-1.5 text-sm font-semibold', className)}
+    {...props}
+  />
+))
+
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors',
+      'focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn('mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+))
+
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(
+      'flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    {...props}
+  />
+))
+
+Textarea.displayName = 'Textarea'
+
+export { Textarea }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,12 +3,12 @@ import { NextResponse } from 'next/server'
 
 const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)'])
 
-export default clerkMiddleware((auth, req) => {
+export default clerkMiddleware(async (auth, req) => {
   // If it's a public route, allow access
   if (isPublicRoute(req)) return NextResponse.next()
 
   // For protected routes, check authentication
-  const { userId } = auth()
+  const { userId } = await auth()
   if (!userId) {
     return NextResponse.redirect(new URL('/sign-in', req.url))
   }

--- a/src/types/pdf-parse.d.ts
+++ b/src/types/pdf-parse.d.ts
@@ -1,0 +1,22 @@
+declare module 'pdf-parse' {
+  interface PDFParseResult {
+    numpages: number
+    numrender: number
+    info: Record<string, unknown>
+    metadata: unknown
+    version: string
+    text: string
+  }
+
+  type PDFData = ArrayBuffer | Uint8Array | Buffer
+
+  interface PDFParseOptions {
+    max?: number
+    version?: string
+  }
+
+  export default function pdf(
+    data: PDFData,
+    options?: PDFParseOptions
+  ): Promise<PDFParseResult>
+}


### PR DESCRIPTION
## Summary
- extend Convex schema and analytics logic to support hired candidates and track update metadata
- harden job, candidate, and email flows by fixing type usage and wiring toast notifications
- add missing shadcn-inspired UI primitives and pdf-parse types required by the app

## Testing
- pnpm type-check

------
https://chatgpt.com/codex/tasks/task_e_68ca061c33d0832698f36ed13af659e3